### PR TITLE
Dispose StarWars schema object.

### DIFF
--- a/src/GraphQL.GraphiQL/Bootstrapper.cs
+++ b/src/GraphQL.GraphiQL/Bootstrapper.cs
@@ -27,7 +27,10 @@ namespace GraphQL.GraphiQL
             container.Register<HumanInputType>();
             container.Register<DroidType>();
             container.Register<CharacterInterface>();
-            container.Singleton(new StarWarsSchema(new FuncDependencyResolver(type => container.Get(type))));
+            using (var starWarsSchema = new StarWarsSchema(new FuncDependencyResolver(type => container.Get(type))))
+            {
+                container.Singleton(starWarsSchema);
+            }
 
             return container;
         }


### PR DESCRIPTION
The StarWarsSchema class inherits Schema class. In the schema class IDisposable is implemented. Hence we can dispose the schema object once the singleton object is added to the container